### PR TITLE
update Rcpp engine example to reflect single calling convention

### DIFF
--- a/029-engine-Rcpp.Rmd
+++ b/029-engine-Rcpp.Rmd
@@ -4,29 +4,31 @@
 opts_chunk$set(cache = TRUE) # because the compilation takes time, let's cache it
 ```
 
-When the chunk option `engine='Rcpp'` is specified, the code chunk will be compiled through **Rcpp** via `cppFunction()` or `sourceCpp()` (the latter is called if an `Rcpp::export` attribute was detected in the code chunk).
+When the chunk option `engine='Rcpp'` is specified, the code chunk will be compiled through **Rcpp** via `sourceCpp()`:
 
 Test for `fibonacci`:
 
 ```{r fibCpp, engine='Rcpp'}
+#include <Rcpp.h>
+
+// [[Rcpp::export]]
 int fibonacci(const int x) {
     if (x == 0 || x == 1) return(x);
     return (fibonacci(x - 1)) + fibonacci(x - 2);
 }
 ```
 
-It can be called as a normal R function now:
+Because `fibonacci` was defined with the `Rcpp::export` attribute it can now be called as a normal R function:
 
 ```{r fibTest, dependson='fibCpp'}
 fibonacci(10L)
 fibonacci(20L)
 ```
 
-The above example defines a single C++ function by calling `cppFunction()`(which automatically includes the `<Rcpp.h>` header). If you want to define multiple functions (or helper functions that are not exported) then you need to add the appropriate includes and `Rcpp::export` attributes. For example:
+You can define multiple functions (or helper functions that are not exported) within Rcpp code chunks:
 
 ```{r multipleCpp, engine='Rcpp'}
 #include <Rcpp.h>
-
 using namespace Rcpp;
 
 // [[Rcpp::export]]
@@ -92,4 +94,4 @@ A test:
 fastLm(rnorm(10), matrix(1:20, ncol = 2))
 ```
 
-Finally, you can pass additional arguments to `cppFunction()` or `sourceCpp()` via the chunk option `engine.opts`. For example, we can use the **RcppArmadillo** package via the depends argument: ```` ```{r lmCpp2, engine.opts=list(depends='RcppArmadillo')} ````, or specify `engine.opts=list(showOutput=TRUE, rebuild=FALSE)` to show the output of `R CMD SHLIB`.
+Finally, you can pass additional arguments to `sourceCpp()` via the chunk option `engine.opts`. For example, we can specify `engine.opts=list(showOutput=TRUE, rebuild=FALSE)` to show the output of `R CMD SHLIB`.

--- a/029-engine-Rcpp.md
+++ b/029-engine-Rcpp.md
@@ -3,12 +3,15 @@
 
 
 
-When the chunk option `engine='Rcpp'` is specified, the code chunk will be compiled through **Rcpp** via `cppFunction()` or `sourceCpp()` (the latter is called if an `Rcpp::export` attribute was detected in the code chunk).
+When the chunk option `engine='Rcpp'` is specified, the code chunk will be compiled through **Rcpp** via `sourceCpp()`:
 
 Test for `fibonacci`:
 
 
 ```cpp
+#include <Rcpp.h>
+
+// [[Rcpp::export]]
 int fibonacci(const int x) {
     if (x == 0 || x == 1) return(x);
     return (fibonacci(x - 1)) + fibonacci(x - 2);
@@ -16,7 +19,7 @@ int fibonacci(const int x) {
 ```
 
 
-It can be called as a normal R function now:
+Because `fibonacci` was defined with the `Rcpp::export` attribute it can now be called as a normal R function:
 
 
 ```r
@@ -36,12 +39,11 @@ fibonacci(20L)
 ```
 
 
-The above example defines a single C++ function by calling `cppFunction()`(which automatically includes the `<Rcpp.h>` header). If you want to define multiple functions (or helper functions that are not exported) then you need to add the appropriate includes and `Rcpp::export` attributes. For example:
+You can define multiple functions (or helper functions that are not exported) within Rcpp code chunks:
 
 
 ```cpp
 #include <Rcpp.h>
-
 using namespace Rcpp;
 
 // [[Rcpp::export]]
@@ -113,16 +115,15 @@ fastLm(rnorm(10), matrix(1:20, ncol = 2))
 
 ```
 ## $coefficients
-##          [,1]
-## [1,] -0.13452
-## [2,]  0.05255
+##         [,1]
+## [1,]  0.3622
+## [2,] -0.1559
 ## 
 ## $stderr
 ##         [,1]
-## [1,] 0.16953
-## [2,] 0.06673
-## 
+## [1,] 0.19370
+## [2,] 0.07624
 ```
 
 
-Finally, you can pass additional arguments to `cppFunction()` or `sourceCpp()` via the chunk option `engine.opts`. For example, we can use the **RcppArmadillo** package via the depends argument: ```` ```{r lmCpp2, engine.opts=list(depends='RcppArmadillo')} ````, or specify `engine.opts=list(showOutput=TRUE, rebuild=FALSE)` to show the output of `R CMD SHLIB`.
+Finally, you can pass additional arguments to `sourceCpp()` via the chunk option `engine.opts`. For example, we can specify `engine.opts=list(showOutput=TRUE, rebuild=FALSE)` to show the output of `R CMD SHLIB`.


### PR DESCRIPTION
See knitr pull request: https://github.com/yihui/knitr/pull/427
