### PR TITLE
LaTeX: $\geq$ instead of >=

### DIFF
--- a/005-latex.Rtex
+++ b/005-latex.Rtex
@@ -35,7 +35,7 @@ value of length 0 will be removed from the output, \rinline{x[1] =
   2011; NULL} but it was indeed evaluated, e.g. now the first element
 of x becomes \rinline{x[1]}.
 
-How about figures? Let's use the Cairo PDF device (assumes R >=
+How about figures? Let's use the Cairo PDF device (assumes R $\geq$
 2.14.0).
 
 %% begin.rcode cairo-scatter, dev='cairo_pdf', fig.width=5, fig.height=5, out.width='.8\\textwidth'


### PR DESCRIPTION
pdfTeX does not like >= syntax.

``` bash
R -e 'library(knitr);knit("005-latex.Rtex")'
```

``` bash
localhost:knitr-examples z$ pdflatex --version
pdfTeX 3.1415926-2.4-1.40.13 (TeX Live 2012)
kpathsea version 6.1.0
Copyright 2012 Peter Breitenlohner (eTeX)/Han The Thanh (pdfTeX).
There is NO warranty.  Redistribution of this software is
covered by the terms of both the pdfTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the pdfTeX source.
Primary author of pdfTeX: Peter Breitenlohner (eTeX)/Han The Thanh (pdfTeX).
Compiled with libpng 1.5.10; using libpng 1.5.10
Compiled with zlib 1.2.7; using zlib 1.2.7
Compiled with xpdf version 3.03
```
