### PR TITLE
Remove % before put statement

### DIFF
--- a/060-engine-sas.Rmd
+++ b/060-engine-sas.Rmd
@@ -4,7 +4,7 @@ As long as SAS is not in your `PATH` variable, you need to specify its full path
 
 ```{r hello-world, engine='sas', engine.path="C:\\Program Files\\SASHome\\x86\\SASFoundation\\9.3\\sas.exe", eval=FALSE}
 data _null_;
-%put 'Hello, world!';
+put 'Hello, world!';
 run;
 ```
 


### PR DESCRIPTION
There is a big difference between `put` and `%put` in SAS.  The latter refers ro the context of SAS macro language - In this case is just a simple data step trying to write something to the log so in this case the correct statement is `put "Hello, World!"` - single/double quotes is irrelevant in this case.