### PR TITLE
Recommend pdf fig.ext for tikz

### DIFF
--- a/058-engine-tikz.Rmd
+++ b/058-engine-tikz.Rmd
@@ -12,7 +12,7 @@ You can pass some options to the engine by defining `engine.opts`, e.g. use your
 
 An example of the tikz-engine from <https://raw.github.com/sdiehl/cats/master/misc/example.md>
 
-```{r tikz-ex, engine = "tikz", fig.cap = "Funky tikz", fig.ext = 'png', cache=TRUE}
+```{r tikz-ex, engine = "tikz", fig.cap = "Funky tikz", fig.ext = 'pdf', cache=TRUE}
 \usetikzlibrary{arrows}
 \begin{tikzpicture}[node distance=2cm, auto,>=latex', thick, scale = 0.5]
 \node (P) {$P$};


### PR DESCRIPTION
I have found that specifying a png `fig.ext` creates poor quality pixelations of the final tikz output.