### PR TITLE
update url for textile alternative to markdown

### DIFF
--- a/105-minimal.Rtextile
+++ b/105-minimal.Rtextile
@@ -1,7 +1,7 @@
 h1. Knitting Textile Files
 
 In this example, we show how to use "*knitr*":http://yihui.name/knitr/ with
- "Textile":http://txstyle.org/.
+ "Textile":https://www.textile-lang.com/.
 
 The syntax for defining code blocks is similar to that of HTML or AsciiDoc.
  You just use @###.@ followed by @begin.rcode@ or @end.rcode@, and then


### PR DESCRIPTION
going through all the examples, I found the url for textile documentation has changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/knitr-examples/65)
<!-- Reviewable:end -->
