### PR TITLE
add an example with `fig.alt` to test the feature introduced in knitr

### DIFF
--- a/067-graphics-options.tex
+++ b/067-graphics-options.tex
@@ -63,7 +63,7 @@
 
 
 
-These options are vectorized for multiple plots per chunk: fig.cap, fig.scap, fig.env, fig.pos, fig.subcap, out.width, out.height, out.extra, fig.link.
+These options are vectorized for multiple plots per chunk: fig.cap, fig.scap, fig.alt, fig.env, fig.pos, fig.subcap, out.width, out.height, out.extra, fig.link.
 When the plot hook is called, the i-th elements of these options will be
 applied to the i-th plot.
 

--- a/120-figure-alt-text.Rmd
+++ b/120-figure-alt-text.Rmd
@@ -1,0 +1,42 @@
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+# simulate pandoc html output
+knitr::opts_knit$set(rmarkdown.pandoc.to = "html")
+```
+
+An alternative text will always be provided with an image tag in html. 
+
+By default, the caption will be used
+
+```{r, fig.cap = "A caption"}
+plot(1:10)
+```
+
+You can use an alt text different than a caption using `fig.alt`
+
+```{r, fig.cap = "A caption", fig.alt = "An alternative text"}
+plot(1:10)
+```
+
+
+It will be evaluated after the chunk like `fig.cap`
+
+```{r, fig.cap = sprintf("%s points", n), fig.alt = sprintf("A graph with %s points", n)}
+n <- 15
+plot(1:n)
+```
+
+And recycled if several graphs
+
+```{r, fig.cap = "A caption", fig.alt = "An alternative text"}
+plot(1:15)
+plot(1:10)
+```
+
+or you can pass a vector
+
+```{r, fig.cap = "Fig1", fig.alt = c("Alt1", "Alt2"), fig.show='hold'}
+plot(1:15)
+plot(1:10)
+```
+

--- a/120-figure-alt-text.md
+++ b/120-figure-alt-text.md
@@ -1,0 +1,73 @@
+
+
+An alternative text will always be provided with an image tag in html. 
+
+By default, the caption will be used
+
+
+```r
+plot(1:10)
+```
+
+![A caption](figure/unnamed-chunk-1-1.png)
+
+You can use an alt text different than a caption using `fig.alt`
+
+
+```r
+plot(1:10)
+```
+
+<div class="figure">
+<img src="figure/unnamed-chunk-2-1.png" alt="An alternative text"  />
+<p class="caption">A caption</p>
+</div>
+
+
+It will be evaluated after the chunk like `fig.cap`
+
+
+```r
+n <- 15
+plot(1:n)
+```
+
+<div class="figure">
+<img src="figure/unnamed-chunk-3-1.png" alt="A graph with 15 points"  />
+<p class="caption">15 points</p>
+</div>
+
+And recycled if several graphs
+
+
+```r
+plot(1:15)
+```
+
+<div class="figure">
+<img src="figure/unnamed-chunk-4-1.png" alt="An alternative text"  />
+<p class="caption">A caption</p>
+</div>
+
+```r
+plot(1:10)
+```
+
+<div class="figure">
+<img src="figure/unnamed-chunk-4-2.png" alt="An alternative text"  />
+<p class="caption">A caption</p>
+</div>
+
+or you can pass a vector
+
+
+```r
+plot(1:15)
+plot(1:10)
+```
+
+<div class="figure">
+<img src="figure/unnamed-chunk-5-1.png" alt="Alt1"  /><img src="figure/unnamed-chunk-5-2.png" alt="Alt2"  />
+<p class="caption">Fig1</p>
+</div>
+


### PR DESCRIPTION
This complements https://github.com/yihui/knitr/pull/1900 where a `fig.alt` option was added to define a diffent alt text than `fig.cap`