### PR TITLE
update rgl example to follow new hook from rgl 0.103.5

### DIFF
--- a/092-latex-rgl.tex
+++ b/092-latex-rgl.tex
@@ -64,13 +64,13 @@ A bug reported at \url{http://cos.name/cn/topic/110742}.
 \hlkwd{head}\hlstd{(hook_rgl)}  \hlcom{# the hook function is defined as this}
 \end{alltt}
 \begin{verbatim}
-##                                                 
-## 1 function (before, options, envir)             
-## 2 {                                             
-## 3     if (before) {                             
-## 4         newwindow <- options$rgl.newwindow    
-## 5         if (!is.null(newwindow) && newwindow) 
-## 6             open3d()
+##                                     
+## 1 function (before, options, envir) 
+## 2 {                                 
+## 3     if (before) {                 
+## 4         do_newwindow(options)     
+## 5         return()                  
+## 6     }
 \end{verbatim}
 \end{kframe}
 \end{knitrout}


### PR DESCRIPTION
This closes #74

@yihui how do you handle change in packages ? 
There is no DESCRIPTION files pinning version requirement for the test. This fix will only work for 0.103.5 which is the last version available on CRAN. 

Causing trouble in CI by the way because binary not yet avilable. I wonder how it behaves with caching of packages